### PR TITLE
fix(management): restrict console requests to same origin

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -181,7 +181,7 @@ Sidebar entry **CPA Credit Manager**:
 /v0/resource/plugins/credit-manager/console
 ```
 
-The page stores the host management token in `sessionStorage` and calls the management API.
+The page stores the host management token in `sessionStorage` and calls only the current CPA's same-origin management API. URL parameters and browser storage cannot override the API root, preventing the management token from being sent to another origin.
 
 | Tab | Contents |
 |---|---|

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ http://<CPA_HOST>:8317/v0/resource/plugins/credit-manager/lookup
 /v0/resource/plugins/credit-manager/console
 ```
 
-页面在浏览器 `sessionStorage` 中保存宿主管理密钥，并调用管理 API。标签页：
+页面在浏览器 `sessionStorage` 中保存宿主管理密钥，并只调用当前 CPA 同源的管理 API。控制台不接受 URL 参数或浏览器存储覆盖 API 根地址，避免管理密钥被发送到其他来源。标签页：
 
 | 标签 | 内容 |
 |------|------|

--- a/internal/management/lookup_test.go
+++ b/internal/management/lookup_test.go
@@ -47,6 +47,36 @@ func TestConsoleModelsDevCatalogIsProxiedAndOptional(t *testing.T) {
 	}
 }
 
+func TestConsoleManagementRequestsAreRestrictedToCurrentOrigin(t *testing.T) {
+	response := consolePage()
+	page := string(response.Body)
+	if got := response.Headers.Get("Content-Security-Policy"); got != "connect-src 'self'" {
+		t.Fatalf("console Content-Security-Policy = %q, want same-origin connections only", got)
+	}
+	for _, forbidden := range []string{
+		`q.get('api_base')`,
+		`q.get('api')`,
+		`id="apiBase"`,
+		`$('apiBase')`,
+		"function apiBase",
+		"function detectDefaultBase",
+		"sessionStorage.setItem(BASE_KEY",
+		"CLIProxyAPI 根地址",
+	} {
+		if strings.Contains(page, forbidden) {
+			t.Fatalf("console allows an untrusted API root through %q", forbidden)
+		}
+	}
+	for _, required := range []string{
+		"return new URL(p, location.origin).toString();",
+		"sessionStorage.removeItem('credit_manager_api_base')",
+	} {
+		if !strings.Contains(page, required) {
+			t.Fatalf("console is missing same-origin management protection %q", required)
+		}
+	}
+}
+
 func TestFXResourceRoute(t *testing.T) {
 	var found bool
 	for _, resource := range Resources() {

--- a/internal/management/pages.go
+++ b/internal/management/pages.go
@@ -62,8 +62,11 @@ func mustPageFile(name string) []byte {
 func consolePage() pluginapi.ManagementResponse {
 	return pluginapi.ManagementResponse{
 		StatusCode: http.StatusOK,
-		Headers:    http.Header{"Content-Type": []string{"text/html; charset=utf-8"}},
-		Body:       consolePageBody,
+		Headers: http.Header{
+			"Content-Type":            []string{"text/html; charset=utf-8"},
+			"Content-Security-Policy": []string{"connect-src 'self'"},
+		},
+		Body: consolePageBody,
 	}
 }
 

--- a/internal/management/web/console.html
+++ b/internal/management/web/console.html
@@ -54,14 +54,11 @@
     <div class="modal-backdrop" id="connectionModal" aria-hidden="true">
       <section class="connection-modal" role="dialog" aria-modal="true" aria-labelledby="connectionModalTitle">
         <div class="modal-header">
-          <div><h2 class="panel-title" id="connectionModalTitle"><span class="heading-icon" aria-hidden="true"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5.5 2.5v3M10.5 2.5v3M3.9 5.5h8.2v2.3a4.1 4.1 0 0 1-8.2 0z"/><path d="M8 11.9v1.6"/></svg></span>连接设置</h2><p class="hint">连接信息仅保存于当前浏览器会话。</p></div>
+          <div><h2 class="panel-title" id="connectionModalTitle"><span class="heading-icon" aria-hidden="true"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M5.5 2.5v3M10.5 2.5v3M3.9 5.5h8.2v2.3a4.1 4.1 0 0 1-8.2 0z"/><path d="M8 11.9v1.6"/></svg></span>连接设置</h2><p class="hint">管理密钥仅保存于当前浏览器会话，请求固定发送到当前 CPA。</p></div>
           <button class="modal-close" id="btnCloseConnection" aria-label="关闭连接设置"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" aria-hidden="true"><path d="m4 4 8 8M12 4l-8 8"/></svg></button>
         </div>
         <div class="modal-body">
           <div class="connection-form">
-            <label>CLIProxyAPI 根地址
-              <input id="apiBase" type="text" placeholder="例如 http://127.0.0.1:8317" autocomplete="off"/>
-            </label>
             <label>宿主管理密钥（Bearer）
               <input id="mgmtToken" type="password" placeholder="remote-management secret" autocomplete="off"/>
             </label>

--- a/internal/management/web/console.js
+++ b/internal/management/web/console.js
@@ -1,7 +1,6 @@
 
 (function () {
   const TOKEN_KEY = 'credit_manager_mgmt_token';
-  const BASE_KEY = 'credit_manager_api_base';
   const TOKEN_UNIT_KEY = 'credit_manager_token_unit';
   const CURRENCY_KEY = 'credit_manager_currency';
   const USD_CNY_RATE_KEY = 'credit_manager_usd_cny_rate';
@@ -26,7 +25,7 @@
     '计费方式': { 'zh-TW':'計費方式', en:'Billing mode', ru:'Режим тарифа' }, '按 Token（USD / 1M）': { 'zh-TW':'按 Token（USD / 1M）', en:'Per token (USD / 1M)', ru:'За токен (USD / 1M)' }, '按张（出图）': { 'zh-TW':'按張（出圖）', en:'Per image', ru:'За изображение' }, '每张 USD': { 'zh-TW':'每張 USD', en:'USD / image', ru:'USD / изображение' }, '出图': { 'zh-TW':'出圖', en:'Image', ru:'Картинка' },     '按张计费': { 'zh-TW':'按張計費', en:'Billed per image', ru:'За картинку' },
     '从请求、Token 到费用的可筛选账本视图。': { 'zh-TW':'從請求、Token 到費用的可篩選帳本檢視。', en:'A filterable ledger view from requests and tokens to costs.', ru:'Фильтруемый журнал от запросов и токенов до расходов.' }, '实时汇总': { 'zh-TW':'即時彙總', en:'Live summary', ru:'Сводка в реальном времени' }, '统计筛选': { 'zh-TW':'統計篩選', en:'Usage filters', ru:'Фильтры статистики' }, '应用筛选': { 'zh-TW':'套用篩選', en:'Apply filters', ru:'Применить фильтры' }, '清除筛选': { 'zh-TW':'清除篩選', en:'Clear filters', ru:'Очистить фильтры' }, '按密钥汇总': { 'zh-TW':'依密鑰彙總', en:'By key', ru:'По ключам' }, '按模型汇总': { 'zh-TW':'依模型彙總', en:'By model', ru:'По моделям' }, '最近明细': { 'zh-TW':'最近明細', en:'Recent activity', ru:'Последние записи' },
     '关闭提示': { 'zh-TW':'關閉提示', en:'Close notification', ru:'Закрыть уведомление' }, '取消': { 'zh-TW':'取消', en:'Cancel', ru:'Отмена' }, '保存规则': { 'zh-TW':'儲存規則', en:'Save rule', ru:'Сохранить правило' }, '删除': { 'zh-TW':'刪除', en:'Delete', ru:'Удалить' }, '编辑': { 'zh-TW':'編輯', en:'Edit', ru:'Изменить' }, '复制密钥': { 'zh-TW':'複製密鑰', en:'Copy key', ru:'Копировать ключ' }, '管理密钥': { 'zh-TW':'管理密鑰', en:'Manage key', ru:'Управлять ключом' },
-    'CLIProxyAPI 根地址': { 'zh-TW':'CLIProxyAPI 根位址', en:'CLIProxyAPI base URL', ru:'Базовый URL CLIProxyAPI' }, '宿主管理密钥（Bearer）': { 'zh-TW':'宿主管理金鑰（Bearer）', en:'Host management token (Bearer)', ru:'Токен управления хостом (Bearer)' }, '清除本地信息': { 'zh-TW':'清除本機資訊', en:'Clear local data', ru:'Очистить локальные данные' }, '连接并加载': { 'zh-TW':'連線並載入', en:'Connect and load', ru:'Подключиться и загрузить' },
+    '宿主管理密钥（Bearer）': { 'zh-TW':'宿主管理金鑰（Bearer）', en:'Host management token (Bearer)', ru:'Токен управления хостом (Bearer)' }, '清除本地信息': { 'zh-TW':'清除本機資訊', en:'Clear local data', ru:'Очистить локальные данные' }, '连接并加载': { 'zh-TW':'連線並載入', en:'Connect and load', ru:'Подключиться и загрузить' },
     '创建密钥': { 'zh-TW':'建立密鑰', en:'Create key', ru:'Создать ключ' }, '保存策略': { 'zh-TW':'儲存策略', en:'Save policy', ru:'Сохранить политику' }, '确认轮换': { 'zh-TW':'確認輪換', en:'Confirm rotation', ru:'Подтвердить ротацию' }, '新增价格规则': { 'zh-TW':'新增價格規則', en:'Add pricing rule', ru:'Добавить правило цены' }, '编辑价格规则': { 'zh-TW':'編輯價格規則', en:'Edit pricing rule', ru:'Изменить правило цены' },
     '生成方式': { 'zh-TW':'產生方式', en:'Key material', ru:'Способ создания' },
     '密钥已启用': { 'zh-TW':'密鑰已啟用', en:'Key enabled', ru:'Ключ включён' },
@@ -69,7 +68,7 @@
     '标签': { 'zh-TW':'標籤', en:'Label', ru:'Метка' }, '可用模型': { 'zh-TW':'可用模型', en:'Allowed models', ru:'Доступные модели' }, '密钥限额': { 'zh-TW':'密鑰限額', en:'Key limits', ru:'Лимиты ключа' }, '已用 / 剩余': { 'zh-TW':'已用 / 剩餘', en:'Used / remaining', ru:'Использовано / остаток' }, '操作': { 'zh-TW':'操作', en:'Actions', ru:'Действия' },
     '全部模型': { 'zh-TW':'全部模型', en:'All models', ru:'Все модели' }, '暂无密钥': { 'zh-TW':'暫無密鑰', en:'No keys', ru:'Нет ключей' }, '已删除': { 'zh-TW':'已刪除', en:'Deleted', ru:'Удалено' }, '(无标签)': { 'zh-TW':'(無標籤)', en:'(no label)', ru:'(без метки)' },
     '还没有密钥。点击右上角“添加密钥”创建第一个额度凭证。': { 'zh-TW':'還沒有密鑰。點擊右上角「新增密鑰」建立第一個額度憑證。', en:'No keys yet. Use Add key in the top right to create the first credential.', ru:'Ключей пока нет. Нажмите «Добавить ключ», чтобы создать первую учётную запись.' },
-    '连接信息仅保存于当前浏览器会话。': { 'zh-TW':'連線資訊僅保存在目前瀏覽器工作階段。', en:'Connection details stay in this browser session only.', ru:'Данные подключения хранятся только в этом сеансе браузера.' },
+    '管理密钥仅保存于当前浏览器会话，请求固定发送到当前 CPA。': { 'zh-TW':'管理金鑰僅保存在目前瀏覽器工作階段，請求固定傳送到目前 CPA。', en:'The management token stays in this browser session, and requests are restricted to the current CPA.', ru:'Токен управления хранится только в этом сеансе, а запросы отправляются только текущему CPA.' },
     '基础信息': { 'zh-TW':'基礎資訊', en:'Basics', ru:'Основное' }, '标签与额度': { 'zh-TW':'標籤與額度', en:'Label and quotas', ru:'Метка и лимиты' },
     '可用模型（多选；不选=全部）': { 'zh-TW':'可用模型（多選；不選=全部）', en:'Allowed models (multi-select; none = all)', ru:'Доступные модели (несколько; пусто = все)' },
     '正在加载当前代理可用模型…': { 'zh-TW':'正在載入目前代理可用模型…', en:'Loading current proxy models…', ru:'Загрузка моделей прокси…' },
@@ -607,34 +606,14 @@
     return ($('mgmtToken').value || sessionStorage.getItem(TOKEN_KEY) || '').trim();
   }
 
-  function detectDefaultBase() {
-    try {
-      const q = new URLSearchParams(location.search || '');
-      const fromQuery = (q.get('api_base') || q.get('api') || '').trim();
-      if (fromQuery) return fromQuery.replace(/\/$/, '');
-    } catch (_) {}
-    // Resource page served by CLIProxyAPI itself.
-    if ((location.pathname || '').indexOf('/v0/resource/plugins/') === 0) {
-      return location.origin;
-    }
-    return (sessionStorage.getItem(BASE_KEY) || '').trim().replace(/\/$/, '');
-  }
-
-  function apiBase() {
-    const raw = ($('apiBase').value || sessionStorage.getItem(BASE_KEY) || '').trim().replace(/\/$/, '');
-    return raw;
-  }
-
   function managementURL(path) {
-    const base = apiBase();
     const p = '/v0/management/' + String(path || '').replace(/^\/+/, '');
-    return base ? (base + p) : p;
+    return new URL(p, location.origin).toString();
   }
 
   function hostURL(path) {
-    const base = apiBase();
     const p = '/' + String(path || '').replace(/^\/+/, '');
-    return base ? (base + p) : p;
+    return new URL(p, location.origin).toString();
   }
 
   function errorMessage(data, text, status) {
@@ -677,7 +656,7 @@
         },
       });
     } catch (e) {
-      throw new Error('网络失败: ' + (e && e.message ? e.message : e) + '。请检查 API 根地址是否可访问。');
+      throw new Error('网络失败: ' + (e && e.message ? e.message : e) + '。请检查当前 CPA 是否可访问。');
     }
     const text = await res.text();
     let data = null;
@@ -835,7 +814,7 @@
     try {
       res = await fetch(url, opts);
     } catch (e) {
-      throw new Error('网络失败: ' + (e && e.message ? e.message : e) + '。请检查 API 根地址是否可访问，以及是否跨域被浏览器拦截。');
+      throw new Error('网络失败: ' + (e && e.message ? e.message : e) + '。请检查当前 CPA 是否可访问。');
     }
     const text = await res.text();
     let data = null;
@@ -843,7 +822,7 @@
     if (!res.ok) {
       const err = (data && (data.error || data.message)) || text || res.statusText || ('HTTP ' + res.status);
       if (res.status === 404) {
-        throw new Error('Not Found（404）：未找到管理接口 ' + url + '。请把「CLIProxyAPI 根地址」改成代理实际地址（如 http://127.0.0.1:8317），确认已部署最新 DLL 并重启宿主；密钥必须是宿主 management secret。');
+        throw new Error('Not Found（404）：未找到管理接口 ' + url + '。请确认已部署最新插件并重启宿主；密钥必须是宿主 management secret。');
       }
       if (res.status === 401 || res.status === 403) {
         throw new Error((typeof err === 'string' ? err : JSON.stringify(err)) + '（管理密钥错误，或未允许远程管理）');
@@ -4031,7 +4010,7 @@
     const modal = $('connectionModal');
     modal.classList.add('open');
     modal.setAttribute('aria-hidden', 'false');
-    $('apiBase').focus();
+    $('mgmtToken').focus();
   };
 
   // events
@@ -4081,10 +4060,7 @@
   $('btnSaveToken').addEventListener('click', async () => {
     const t = $('mgmtToken').value.trim();
     if (!t) { flash('请输入管理密钥', false); return; }
-    const base = $('apiBase').value.trim().replace(/\/$/, '');
     sessionStorage.setItem(TOKEN_KEY, t);
-    if (base) sessionStorage.setItem(BASE_KEY, base);
-    else sessionStorage.removeItem(BASE_KEY);
     try {
       await reloadWithModelCatalog();
       closeConnectionModal();
@@ -4093,9 +4069,8 @@
   });
   $('btnClearToken').addEventListener('click', () => {
     sessionStorage.removeItem(TOKEN_KEY);
-    sessionStorage.removeItem(BASE_KEY);
     $('mgmtToken').value = '';
-    flash('已清除本地管理密钥与 API 根地址', true);
+    flash('已清除本地管理密钥', true);
   });
   let authQuotaSearchTimer = 0;
   $('authQuotaProviderFilter').addEventListener('change', () => {
@@ -4343,7 +4318,9 @@
   });
 
   // boot
-  const savedBase = detectDefaultBase();
+  // Earlier versions stored a caller-controlled API root. It is no longer
+  // trusted or used; remove it before any request can carry a management token.
+  sessionStorage.removeItem('credit_manager_api_base');
   state.tokenUnit = normalizeTokenUnit(localStorage.getItem(TOKEN_UNIT_KEY) || 'raw');
   state.currency = normalizeCurrency(localStorage.getItem(CURRENCY_KEY) || 'USD');
   state.usdCnyRate = normalizeUsdCnyRate(localStorage.getItem(USD_CNY_RATE_KEY) || DEFAULT_USD_CNY_RATE);
@@ -4354,7 +4331,6 @@
   initPreferences();
   fetchUsdCnyRate(false);
   window.setInterval(() => fetchUsdCnyRate(false), 30 * 60 * 1000);
-  if (savedBase) $('apiBase').value = savedBase;
   setOverviewRangeVisibility();
   setUsageRangeVisibility();
   const saved = sessionStorage.getItem(TOKEN_KEY) || '';


### PR DESCRIPTION
## Summary

- 修复管理控制台信任 `api_base` / `api` URL 参数的问题：当浏览器会话中已有宿主管理密钥时，构造链接可让页面自动把带 `Authorization: Bearer` 的管理请求发送到攻击者控制且允许 CORS 的来源。
- 删除自定义 CLIProxyAPI 根地址输入、URL 参数覆盖和浏览器持久化，所有管理请求与模型发现请求固定基于当前页面的 `location.origin`；页面启动时会在复用已保存管理密钥前清理旧版本遗留的根地址。
- 为控制台增加 `Content-Security-Policy: connect-src 'self'` 纵深防护，并补充安全回归测试及中英文安全边界文档。

## Testing

- `node --check internal/management/web/console.js`：通过。
- `go test ./internal/management`：通过。
- `go test ./internal/management -run TestConsoleManagementRequestsAreRestrictedToCurrentOrigin -count=10`：通过。
- `go test ./...`：本次涉及的包通过；完整套件仍有现存的 OAuth 额度预测测试失败，详见 Risks。

## Risks

- 控制台不再支持通过自定义 API 根地址管理另一个 CPA 实例；这是为了把宿主管理密钥限制在当前 CPA 同源内的有意行为变化。
- 完整测试中 `TestAuthQuotaForecastMatchesHostProviderAliases`、`TestAuthQuotaForecastIncludesFullLocalUsage`、`TestAuthQuotaForecastIgnoresPrePluginUsage` 和 `TestAuthQuotaAntigravityUnmatchedModelDisablesPrediction` 仍会失败；本 PR 未修改 `internal/service`，这些失败在修复前已存在。
- 本 PR 只处理可控 API 根地址导致的管理密钥跨源发送，不包含 ECharts CDN 本地化等其他前端供应链加固。